### PR TITLE
this package doesn't actually seem to depend on haskell98

### DIFF
--- a/ConfigFile.cabal
+++ b/ConfigFile.cabal
@@ -44,7 +44,7 @@ Library
    UndecidableInstances, TypeSynonymInstances, FlexibleContexts,
    FlexibleInstances
   Build-Depends: parsec, base < 5,
-                haskell98, mtl, MissingH>=1.0.0, containers
+                mtl, MissingH>=1.0.0, containers
   GHC-Options: -O2 -Wall
 
 Executable runtests


### PR DESCRIPTION
(and depending on both base and haskell98 breaks builds in GHC 7.1)
