### PR TITLE
Added support for empty sections and empty options.

### DIFF
--- a/src/Data/ConfigFile/Lexer.hs
+++ b/src/Data/ConfigFile/Lexer.hs
@@ -96,8 +96,7 @@ optionkey = many1 oname_chars
 optionvalue = many value_chars
 optionpair :: GenParser Char st (String, String)
 optionpair = do key <- optionkey
-                optionsep
-                value <- optionvalue
+                value <- option "" $ do { optionsep; optionvalue }
                 eolstuff
                 return (key, value)
              <?> "key/value option"

--- a/src/Data/ConfigFile/Parser.hs
+++ b/src/Data/ConfigFile/Parser.hs
@@ -112,7 +112,7 @@ sectionhead =
         do {s <- tokeng wf; return $ strip s}
 
 optionlist :: GeneralizedTokenParser CPTok () [(String, String)]
-optionlist = many1 coption
+optionlist = many coption
 
 coption :: GeneralizedTokenParser CPTok () (String, String)
 coption =


### PR DESCRIPTION
Empty section support was requested by GitHub user qnikst (July 27, 2011).
With this changeset, an empty section has an empty list of options.
Empty option support allows one to parse MySQL my.cnf files.
With this changeset, an empty option has value the empty string.

Example:

[emptysection]

[mysqldump]
quick
max_allowed_packet = 16M
